### PR TITLE
Bug Out! Update

### DIFF
--- a/src/data/pokemon.js
+++ b/src/data/pokemon.js
@@ -3169,13 +3169,13 @@ const pokemon = [
     name: "Whirlipede",
     id: 544,
     available: true,
-    shinyAvailable: false,
+    shinyAvailable: true,
   },
   {
     name: "Scolipede",
     id: 545,
     available: true,
-    shinyAvailable: false,
+    shinyAvailable: true,
   },
   {
     name: "Cottonee",

--- a/src/data/pokemon.js
+++ b/src/data/pokemon.js
@@ -3163,7 +3163,7 @@ const pokemon = [
     name: "Venipede",
     id: 543,
     available: true,
-    shinyAvailable: false,
+    shinyAvailable: true,
   },
   {
     name: "Whirlipede",
@@ -4327,19 +4327,19 @@ const pokemon = [
   {
     name: "Grubbin",
     id: 736,
-    available: false,
+    available: true,
     shinyAvailable: false,
   },
   {
     name: "Charjabug",
     id: 737,
-    available: false,
+    available: true,
     shinyAvailable: false,
   },
   {
     name: "Vikavolt",
     id: 738,
-    available: false,
+    available: true,
     shinyAvailable: false,
   },
   {


### PR DESCRIPTION
This PR adds the three Pokemon (Grubbin and its evolutions) and the three shinies (Venipede and its evolutions) that debuted during the Bug Out! event.

Sources:
https://pokemongolive.com/en/post/bug-out-returns-2022/
https://pokemongo.fandom.com/wiki/Bug_Out_2022