### PR TITLE
Fashion Week and Evolving Stars 2022 events

### DIFF
--- a/src/data/pokemon.js
+++ b/src/data/pokemon.js
@@ -4651,7 +4651,7 @@ const pokemon = [
   {
     name: "Cosmoem",
     id: 790,
-    available: false,
+    available: true,
     shinyAvailable: false,
   },
   {

--- a/src/data/pokemon.js
+++ b/src/data/pokemon.js
@@ -3967,7 +3967,7 @@ const pokemon = [
     name: "Furfrou",
     id: 676,
     available: true,
-    shinyAvailable: false,
+    shinyAvailable: true,
   },
   {
     name: "Espurr",
@@ -4213,7 +4213,7 @@ const pokemon = [
     name: "Yveltal",
     id: 717,
     available: true,
-    shinyAvailable: false,
+    shinyAvailable: true,
   },
   {
     name: "Zygarde",
@@ -4393,13 +4393,13 @@ const pokemon = [
   {
     name: "Mareanie",
     id: 747,
-    available: false,
+    available: true,
     shinyAvailable: false,
   },
   {
     name: "Toxapex",
     id: 748,
-    available: false,
+    available: true,
     shinyAvailable: false,
   },
   {


### PR DESCRIPTION
Fashion week: Mareanie and evolution Tokapex added, Furfrou and Ylveltal are new shinies
https://pokemongolive.com/en/post/fashion-week-2022/ (doesn't mention shiny Ylveltal)
https://pokemongo.fandom.com/wiki/Fashion_Week_2022

Evolving Stars: Cosmoem added, no new shinies
https://pokemongolive.com/en/post/evolving-stars-2022/
https://pokemongo.fandom.com/wiki/Evolving_Stars