### PR TITLE
Update UI with fresh design

### DIFF
--- a/public/images/app-logo.svg
+++ b/public/images/app-logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#fd5f00"/>
+      <stop offset="100%" style="stop-color:#fca15c"/>
+    </linearGradient>
+  </defs>
+  <circle cx="50" cy="50" r="45" fill="url(#grad)"/>
+  <path d="M30 52 l12 12 25 -25" fill="none" stroke="white" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
   <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/images/icons/favicon-16x16.png" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="theme-color" content="#445BA1" />
+  <meta name="theme-color" content="#fd5f00" />
 
   <style>
     @font-face {
@@ -27,6 +27,7 @@
       padding: 0;
       margin: 0;
       font-family: "Varela", "Segoe UI", "Helvetica Neue", Arial;
+      background: #f5f5f7;
     }
   </style>
 </head>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "GOChecklists",
   "short_name": "GOChecklists",
-  "theme_color": "#445BA1",
+  "theme_color": "#fd5f00",
   "background_color": "#000000",
   "display": "standalone",
   "scope": "/",

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -5,12 +5,13 @@ import styled from "styled-components";
 const HeaderContainer = styled.h1`
   display: flex;
   align-items: center;
-  background-color: #445ba1;
+  background: linear-gradient(45deg, #fd5f00, #fca15c);
   color: white;
   margin: 0;
   padding: 0;
   font-size: 1.5em;
   text-align: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 
   span {
     display: inline-block;
@@ -38,6 +39,11 @@ const HeaderContainer = styled.h1`
   .settings {
     background-image: url(/images/settings.svg);
   }
+  .logo {
+    width: 2.5em;
+    height: 2.5em;
+    margin-right: 0.3em;
+  }
   .title {
     flex-grow: 2;
   }
@@ -61,6 +67,7 @@ export default function Header({ title, settingsClick }) {
         </button>
       )}
 
+      <img className="logo" src="/images/app-logo.svg" alt="App logo" />
       <span className="title">{title}</span>
 
       {settingsClick && (

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -4,8 +4,16 @@ import styled from "styled-components";
 
 import Header from "./Header";
 
+const Wrapper = styled.div`
+  padding: 1em;
+  background: #f5f5f7;
+  min-height: 100vh;
+`;
+
 const List = styled.ul`
   font-size: 1.25em;
+  list-style: none;
+  padding: 0;
 
   li {
     margin: 20px;
@@ -28,6 +36,7 @@ function Home() {
     <React.Fragment>
       <Header title="GO Checklists"></Header>
 
+      <Wrapper>
       <List>
         <li>
           <Link to="/dex">Dex</Link>
@@ -60,6 +69,7 @@ function Home() {
           </ul>
         </li>
       </List>
+      </Wrapper>
     </React.Fragment>
   )
 }

--- a/src/components/Progressbar.js
+++ b/src/components/Progressbar.js
@@ -3,15 +3,17 @@ import styled from "styled-components";
 
 const ProgressbarContainer = styled.div`
   display: flex;
-  margin: 0.6em 0.5em 0.20em 0.5em;
+  margin: 0.6em 0.5em 0.2em 0.5em;
 
   .progressbar {
-    border: 1px solid gray;
-    border-radius: 5px;
+    border-radius: 6px;
+    background: #eee;
     width: 100%;
+    overflow: hidden;
   }
   .progressbar-contents {
-    height: 25px;
+    height: 16px;
+    background: linear-gradient(90deg, #fd5f00, #fca15c);
   }
   & > span {
     display: flex;
@@ -32,25 +34,6 @@ export default function Progressbar({ value, max }) {
     return ((value / max) * 100) + "%";
   }
 
-  const getBackgroundColor = () => {
-    const percent = Math.round((value / max) * 100);
-    return (percent <= 6) ? "#FB041E" :
-      (percent > 6 && percent <= 12) ? "#FD2222" :
-      (percent > 12 && percent <= 18) ? "#FC4926" :
-      (percent > 18 && percent <= 24) ? "#FC6628" :
-      (percent > 24 && percent <= 30) ? "#FE882A" :
-      (percent > 30 && percent <= 36) ? "#FFA52E" :
-      (percent > 36 && percent <= 42) ? "#FEC230" :
-      (percent > 42 && percent <= 48) ? "#FFDE34" :
-      (percent > 48 && percent <= 54) ? "#F4DE2B" :
-      (percent > 54 && percent <= 60) ? "#E7DD25" :
-      (percent > 60 && percent <= 66) ? "#DBDD1C" :
-      (percent > 66 && percent <= 72) ? "#CEDC18" :
-      (percent > 72 && percent <= 78) ? "#C3DC0E" :
-      (percent > 78 && percent <= 84) ? "#B6DC07" :
-      (percent > 84 && percent <= 90) ? "#A9DC03" : "#9ADA00";
-  }
-
   return (
     <ProgressbarContainer>
       <div className="progressbar">
@@ -58,7 +41,6 @@ export default function Progressbar({ value, max }) {
           className="progressbar-contents"
           style={{
             width: getWidth(),
-            backgroundColor: getBackgroundColor()
           }}>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a simple gradient logo
- modernize the header with a gradient background and logo
- tweak the progress bar style
- wrap the home page content in a padded wrapper
- switch theme color and page background to a light grey

## Testing
- `CI=true npm test --silent` *(fails: Cannot find module '@testing-library/jest-dom/extend-expect')*

------
https://chatgpt.com/codex/tasks/task_e_68408e409f808321a40530ac18c03cc0